### PR TITLE
Usar nombre original en la descarga

### DIFF
--- a/app.py
+++ b/app.py
@@ -288,6 +288,7 @@ def home():
 
         # Guardar en sesión
         session["file_xlsx"] = f_xlsx.read()
+        session["file_xlsx_name"] = Path(f_xlsx.filename).stem
         session["mapping_name"] = mapping_choice
 
         wb = openpyxl.load_workbook(io.BytesIO(session["file_xlsx"]), read_only=True)
@@ -340,11 +341,12 @@ def mapping():
 
         out.seek(0)
 
+        base = session.get("file_xlsx_name", slugify(mapping_name))
         session.clear()  # limpiamos todo
         return send_file(
             out,
             as_attachment=True,
-            download_name=f"unificado_{slugify(mapping_name)}.xlsx",
+            download_name=f"Unificado_{base}.xlsx",
             mimetype="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
         )
 


### PR DESCRIPTION
## Resumen
- almacena en sesión el nombre base del Excel subido
- usa ese nombre para el archivo unificado

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt`
- ejecuta un ejemplo con Flask test_request_context y obtiene `Unificado_UAI.xlsx`


------
https://chatgpt.com/codex/tasks/task_e_685ada25e830832f88fd10b811237965