### PR TITLE
Configura sesiones permanentes en Flask

### DIFF
--- a/app.py
+++ b/app.py
@@ -42,7 +42,7 @@ app.secret_key = os.getenv("FLASK_SECRET", "cambia_esta_clave_supersecreta")
 
 app.config["SESSION_TYPE"] = "filesystem"
 app.config["SESSION_FILE_DIR"] = Path("flask_session").resolve()
-app.config["SESSION_PERMANENT"] = False
+app.config["SESSION_PERMANENT"] = True
 Session(app)
 
 app.permanent_session_lifetime = timedelta(hours=3)
@@ -247,6 +247,7 @@ def login():
         user = request.form.get("username")
         pwd = request.form.get("password")
         if user == "AnalisisLP" and pwd == "AnalisisLP2025":
+            session.permanent = True
             session["user"] = "AnalisisLP"
             return redirect(url_for("home"))
         error = "Credenciales incorrectas"


### PR DESCRIPTION
## Resumen
- habilitar sesiones permanentes en la configuración global
- definir la sesión como permanente al iniciar sesión

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_685c5649898c832faf71144eb3b5b613