### PR TITLE
Refina manejo de errores en mapeo

### DIFF
--- a/app.py
+++ b/app.py
@@ -378,8 +378,16 @@ def mapping():
                 download_name=f"Unificado_{base}.xlsx",
                 mimetype="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
             )
-        except (BadZipFile, ValueError, Exception):
-            flash("Ocurrió un error al procesar los archivos", "danger")
+        except BadZipFile:
+            flash("El archivo Excel parece estar dañado o no es válido.", "danger")
+            app.logger.exception("Error al unificar archivos")
+            return redirect(url_for("mapping"))
+        except ValueError as exc:
+            flash(f"Error de datos: {exc}", "danger")
+            app.logger.exception("Error al unificar archivos")
+            return redirect(url_for("mapping"))
+        except Exception:
+            flash("Ocurrió un error inesperado al procesar los archivos.", "danger")
             app.logger.exception("Error al unificar archivos")
             return redirect(url_for("mapping"))
 


### PR DESCRIPTION
## Summary
- maneja BadZipFile, ValueError y Exception en bloques separados
- mantiene el logging para cada excepción

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_685c5ac83124832f8c8baa0f238aca26